### PR TITLE
Remove reference to `css` prop in docs

### DIFF
--- a/src/props.md
+++ b/src/props.md
@@ -139,26 +139,6 @@ See the [styled-system][responsive] docs for more info.
 />
 ```
 
-## `css` prop
-
-All Rebass components include a `css` prop,
-which gives you low-level access to apply any CSS to a component.
-This works well as an escape hatch for one-off styles or as another way to extend Rebass components.
-
-```jsx
-// example of using the `css` prop
-const GrowingButton = props =>
-  <Button
-    {...props}
-    css={{
-      transition: 'transform .1s ease-out',
-      '&:hover': {
-        transform: 'scale(1.1)'
-      }
-    }}
-  />
-```
-
 ## Component-Specific Props
 
 Refer to each component's docs for addition props:


### PR DESCRIPTION
Per https://github.com/rebassjs/rebass/pull/536 the `css` prop has been removed. I personally got around the absence of the `css` prop by falling back to `style` prop––although I'd be happy to learn of a better alternative.

```diff
- <Box p={2} css={{ flexGrow: 1, border: "1px solid gray" }}>
+ <Box p={2} style={{ flexGrow: 1, border: "1px solid gray" }}>
```